### PR TITLE
Add a "gut-based" Huntsman priority list

### DIFF
--- a/Priorities/Rogue_Huntsman.lua
+++ b/Priorities/Rogue_Huntsman.lua
@@ -1,0 +1,61 @@
+local a = Protipper.API
+local cd = 0.75
+
+Protipper.Priorities["Huntsman"] = {
+	{	
+		"Animalism",
+		function()
+			return (a.Cooldown("Animalism") < cd)
+				and (a.RemainingTime("player.pet", "Feral Aggression") > 0)
+		end
+	},
+
+	{
+		"Feral Aggression",
+		function()
+			return (a.Cooldown("Feral Aggression") < cd) and (a.ComboPoints() == 5)
+		end
+	},
+
+	{
+		"Twin Shot",
+		function()
+			return a.ComboPoints() == 5
+		end
+	},
+
+	{
+		"Shadow Fire",
+		function()
+			return (a.Cooldown("Shadow Fire") < cd) and (a.ComboPoints() < 5)
+		end
+	},
+
+	{
+		"Splinter Shot",
+		function()
+			return a.RemainingTime("player.target", "Splinter Shot") < cd
+		end
+	},
+
+	{
+		"Ace Shot",
+		function()
+			return a.RemainingTime("player.target", "Ace Shot") < 1
+		end
+	},
+
+	{
+		"Shadow Fire",
+		function()
+			return a.RemainingTime("player", "Shadow Fire") < cd
+		end
+	},
+
+	{
+		"Ace Shot",
+		function()
+			return true
+		end
+	}
+}


### PR DESCRIPTION
Accepting this pull request resolves #1.

Currently this is entirely based on my own hunches and will surely need revision.
It adds a ["Huntsman] entry to Protipper.Priorities which is a list of maps of
the following form:

``` lua
Protipper.Priorities["Huntsman"] = {
    {
        "Ability Name",
        function()
            -- Return true if ability meets the conditions for using it.
        end
    },
    ...
}
```
